### PR TITLE
minimal docker images using nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ utils/*.cpp
   git clone https://github.com/sobottasgithub/Tablo
 ```
 
-2. configure for yor system
+2. configure for your system
 ```bash
  cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
 ```
@@ -46,3 +46,11 @@ utils/*.cpp
 ```
    cmake --install build
 ```
+
+### Using the nix generated docker images
+
+The flake in this repository allowes you to build minimal docker images that avoid as much bloat as possible.
+
+To use this feature, you NEED to use nix. Download available at: https://nixos.org/
+
+You can either run the builds yourself or use the `./build-image-nix.sh` script!

--- a/TCTest/CMakeLists.txt
+++ b/TCTest/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.h")
 
-add_executable(tabcrypt_test ${SOURCES})
+add_executable(tabcrypt-test ${SOURCES})
 
 # Link against the tabcrypt library
-target_link_libraries(tabcrypt_test PRIVATE tabcrypt)
+target_link_libraries(tabcrypt-test PRIVATE tabcrypt)
 
-install(TARGETS tabcrypt_test DESTINATION bin)
+install(TARGETS tabcrypt-test DESTINATION bin)

--- a/TabloClient/CMakeLists.txt
+++ b/TabloClient/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.h")
 
-add_executable(tablo_client ${SOURCES})
+add_executable(tablo-client ${SOURCES})
 
 # Link against the tabcrypt library
-target_link_libraries(tablo_client PRIVATE tabcrypt)
+target_link_libraries(tablo-client PRIVATE tabcrypt)
 
-install(TARGETS tablo_client DESTINATION bin)
+install(TARGETS tablo-client DESTINATION bin)

--- a/TabloMaster/CMakeLists.txt
+++ b/TabloMaster/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.h")
 
-add_executable(tablo_master ${SOURCES})
+add_executable(tablo-master ${SOURCES})
 
 # Link against the tabcrypt library
-target_link_libraries(tablo_master PRIVATE tabcrypt)
+target_link_libraries(tablo-master PRIVATE tabcrypt)
 
-install(TARGETS tablo_master DESTINATION bin)
+install(TARGETS tablo-master DESTINATION bin)

--- a/TabloNode/CMakeLists.txt
+++ b/TabloNode/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.h")
 
-add_executable(tablo_node ${SOURCES})
+add_executable(tablo-node ${SOURCES})
 
 # Link against the tabcrypt library
-target_link_libraries(tablo_node PRIVATE tabcrypt)
+target_link_libraries(tablo-node PRIVATE tabcrypt)
 
-install(TARGETS tablo_node DESTINATION bin)
+install(TARGETS tablo-node DESTINATION bin)

--- a/build-image-nix.sh
+++ b/build-image-nix.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# WARNING: This is not a nix generated script. Its just a simplification for running manual nix builds!
+
+echo "building tablo-node image"
+nix build -v .#tablo-node-docker && docker load < result
+
+echo "building tablo-master image"
+nix build -v .#tablo-master-docker && docker load < result
+
+echo "building tablo-client image"
+nix build -v .#tablo-client-docker && docker load < result
+
+rm result

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,5 +1,5 @@
 # This script builds the Docker container for this project and tags them
-#!/env bash
+#!/usr/bin/env bash
 set -e
 
 source ./.env


### PR DESCRIPTION
# Minimal Nix Docker Images (MNDI)

This PR introduces docker images built using nix (dockerTools) to reduce the image size from about 1100 MB to 45 MB.

- **update: update naming convention from "_" seperators to "-"**
- **update: introduce nix generated docker images**
- **doc: add readme section about minimal nix images**
